### PR TITLE
✨feature: SP-2/3 Updates

### DIFF
--- a/api/refresh-orders.php
+++ b/api/refresh-orders.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Forces a refresh of orders for a specified item and updates the cache.
+ *
+ * PHP version: 8.0+
+ *
+ * @category API
+ * @package  WFList
+ * @author   Keith Solomon <keith@keithsolmon.net>
+ * @license  MIT License
+ * @version  GIT: $Id$
+ * @link     https://git.keithsolomon.net/keith/Warframe_Shopping_List
+ */
+
+require_once __DIR__ . '/helpers.php';
+
+header('Content-Type: application/json');
+
+$item_slug = $_GET['item_slug'] ?? '';
+
+if (!$item_slug) {
+    http_response_code(400);
+    echo json_encode(['error' => 'item_slug is required']);
+    exit;
+}
+
+// Always fetch fresh from API, then cache and return current cached view
+$orders = fetchPriceFromAPI($item_slug);
+
+if ($orders !== null) {
+    cacheOrders($item_slug, $orders);
+}
+
+// Read back from cache to include normalized structure and timestamp
+$latest = getCachedOrders($item_slug);
+
+if ($latest === null) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Failed to refresh orders']);
+    exit;
+}
+
+echo json_encode([
+    $item_slug => [
+        'name'         => $item_slug,
+        'orders'       => $latest['orders_json'],
+        'last_checked' => $latest['last_checked'],
+    ]
+]);
+

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -23,6 +23,7 @@ body.dark-mode {
 
     .button {
         background-color: var(--colorPrimaryButton);
+        border: 1px solid var(--colorPrimaryButton);
         color: var(--colorWhite);
 
         &:disabled,
@@ -32,6 +33,17 @@ body.dark-mode {
         }
         &:disabled:hover,
         &.added:hover { background-color: var(--colorMedGray); }
+
+        &.ghost {
+            background: transparent;
+            border: 1px solid var(--colorPrimaryButton);
+            color: var(--colorPrimaryButton);
+
+            &:hover {
+                background: var(--colorPrimaryButton);
+                color: var(--colorWhite);
+            }
+        }
     }
 
     .btnMode { color: var(--colorWhite); }
@@ -68,6 +80,13 @@ body.dark-mode {
         }
     }
 
+    /* Stronger focus affordance for search results in dark mode */
+    #item-list li:focus {
+        outline: 3px solid var(--colorPrimary);
+        outline-offset: 2px;
+        background: rgba(50, 145, 165, 0.25);
+    }
+
     #list-select {
         background: var(--colorWhite);
         border: 1px solid var(--colorWhite);
@@ -82,7 +101,13 @@ body.dark-mode {
             .price-card, ul {
                 border-color: var(--colorWhite);
 
-                li { border-color: var(--colorMedGray); }
+                li {
+                    border-color: var(--colorMedGray);
+                    background: transparent; /* Neutral in dark mode too */
+                    transition: background-color 0.2s ease;
+                }
+
+                li:hover { background: rgba(255,255,255,0.06); }
             }
         }
     }
@@ -94,6 +119,12 @@ body.dark-mode {
             #total-cost { color: var(--colorWhite); }
             #price-warning { color: var(--colorWarning); }
         }
+    }
+
+    /* Welcome banner in dark mode */
+    .welcome-banner {
+        background: var(--colorPrimaryDark);
+        border-color: var(--colorPrimary);
     }
 
     #new-list-dialog {

--- a/css/style.css
+++ b/css/style.css
@@ -80,6 +80,38 @@ header, footer {
     }
 }
 
+.welcome-banner {
+    align-items: center;
+    background: #eef7f9;
+    border: 1px solid var(--colorPrimary);
+    border-radius: .5rem;
+    display: flex;
+    gap: .75rem;
+    justify-content: space-between;
+    margin: .25rem .5rem 1rem;
+    padding: .5rem .75rem;
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 200ms ease, transform 200ms ease;
+
+    .welcome-text {
+        align-items: center;
+        display: flex;
+        gap: .5rem;
+        flex-wrap: wrap;
+    }
+}
+
+/* Ensure hidden attribute actually hides despite display:flex above */
+.welcome-banner[hidden] { display: none !important; }
+
+/* Fade-out state */
+.welcome-banner.is-hiding {
+    opacity: 0;
+    transform: translateY(-4px);
+    pointer-events: none;
+}
+
 .main-content {
     display: grid;
     gap: 1.25rem;
@@ -118,7 +150,7 @@ a {
 
 .button {
     background-color: var(--colorPrimary);
-    border: none;
+    border: 1px solid var(--colorPrimary);
     border-radius: .25rem;
     color: var(--colorWhite);
     cursor: pointer;
@@ -338,6 +370,7 @@ a {
 
         #clear-list-btn, #delete-list-btn {
             background-color: var(--colorDanger);
+            border: 1px solid var(--colorDanger);
             color: var(--colorWhite);
 
             &:hover { background-color: var(--colorDangerHover); }
@@ -393,6 +426,14 @@ a {
         display: flex;
         justify-content: space-between;
         padding: .5rem;
+        /* Visible focus ring when navigating with keyboard */
+        &:focus {
+            outline: 3px solid var(--colorPrimary);
+            outline-offset: 2px;
+            background: var(--colorPrimaryDarker);
+        }
+
+        button.ghost { margin-right: .25rem; }
 
         &.stripe {
             background: var(--colorPrimaryDarker);
@@ -489,6 +530,9 @@ a {
     #prices-breakdown {
         padding: 0 1.25rem;
 
+        /* Ensure any accidental stripe classes do not imply meaning here */
+        .stripe { background: transparent !important; }
+
         .kbd-hint { margin-bottom: 1rem; }
 
         h4 {
@@ -510,8 +554,12 @@ a {
                 list-style: none;
                 margin: 0 .5rem .125rem;
                 padding: .375rem .125rem;
+                background: transparent; /* Neutral rows (no implied meaning) */
+                transition: background-color 0.2s ease;
 
                 &:last-child { border-bottom: none; }
+                /* Subtle hover only, to aid scanning without implying status */
+                &:hover { background: rgba(0,0,0,0.03); }
             }
         }
     }
@@ -529,6 +577,11 @@ a {
 #shopping-list-content ul li .actions {
     flex: 0 0 auto;
     margin-left: .5rem;
+}
+
+#shopping-list-content ul li.stripe {
+    background: transparent !important;
+    border: 1px solid var(--colorLightGray) !important;
 }
 
 /* Mobile tab switcher styles */

--- a/index.html
+++ b/index.html
@@ -39,8 +39,16 @@
             <div id="user-auth-area">
                 <!-- User authentication UI will be rendered here by JS -->
             </div>
-
         </header>
+
+        <!-- First-visit welcome banner (shown only for new users) -->
+        <div id="welcome-banner" class="welcome-banner" hidden role="region" aria-label="Welcome banner">
+            <div class="welcome-text">
+                <strong>Welcome!</strong>
+                <span>Start by creating a list, then search to add items.</span>
+            </div>
+            <button id="dismiss-welcome" class="button" aria-label="Dismiss welcome banner">Got it</button>
+        </div>
 
         <div class="mobile-tabs" id="mobile-tabs">
             <button id="tab-items" class="tab-btn">Items</button>

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,5 @@
 /* Service Worker for Warframe Shopping List */
-const VERSION = 'v1.0.6';
+const VERSION = 'v1.0.9';
 const STATIC_CACHE = `wf-static-${VERSION}`;
 const RUNTIME_CACHE = `wf-runtime-${VERSION}`;
 


### PR DESCRIPTION
This PR implements the following changes:

- Onboarding: first-visit cookie + dismissible welcome banner (with fade-out + dark mode).
- Per-item “Refresh best price”: forces latest orders, updates item best price, totals, and prices breakdown; 8s per-item throttle; adds `api/refresh-orders.php`.
- Prices panel: neutral row backgrounds with subtle hover only; removes unintended emphasis; dark-mode parity.
- Accessibility: arrow-key navigation for search results (roving tabindex), Enter to Add, Esc back to search, Home/End jumps; visible focus style; ARIA combobox/listbox with `aria-expanded`,
`aria-selected`, `aria-activedescendant`.
- SW bump: cache version to v1.0.9.
- Notes: Verified in light/dark modes; price refresh respects throttle; banner persists dismissal via `hasVisited` cookie.
